### PR TITLE
SUB-002 — Electron dev runs + postinstall fixed

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -28,3 +28,12 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## Electron install notes (Windows)
+
+This workspace includes a `postinstall` script that forces Electron to download
+its binary during `pnpm install`. If Electron still fails to run, retry:
+
+```bash
+pnpm -C apps/desktop postinstall
+```

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build && electron-builder",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "node node_modules/electron/install.js"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary\n- add a postinstall hook to force Electron binary download\n- document the recovery command in apps/desktop README\n\n## Testing\n- not run (docs/config only)\n\nCloses #2