### PR TITLE
SUB-007 — Application layer (Use Cases V0)

### DIFF
--- a/packages/core/src/application/index.ts
+++ b/packages/core/src/application/index.ts
@@ -1,0 +1,6 @@
+export type { UseCaseResult } from './result'
+export { deleteScaffold } from './useCases/deleteScaffold'
+export { setActiveScaffold } from './useCases/setActiveScaffold'
+export { toggleOverlay } from './useCases/toggleOverlay'
+export { updateOverlayStyle } from './useCases/updateOverlayStyle'
+export { upsertScaffold } from './useCases/upsertScaffold'

--- a/packages/core/src/application/result.ts
+++ b/packages/core/src/application/result.ts
@@ -1,0 +1,5 @@
+import type { DomainIssue } from '../domain/validation'
+
+export type UseCaseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string; issues?: DomainIssue[] }

--- a/packages/core/src/application/useCases/deleteScaffold.ts
+++ b/packages/core/src/application/useCases/deleteScaffold.ts
@@ -1,0 +1,16 @@
+import type { ScaffoldRepositoryPort } from '../../ports/scaffoldRepository'
+import type { UseCaseResult } from '../result'
+
+export const deleteScaffold = async (
+  repository: ScaffoldRepositoryPort,
+  id: string,
+): Promise<UseCaseResult<void>> => {
+  const activeId = await repository.getActiveId()
+  await repository.delete(id)
+
+  if (activeId === id) {
+    await repository.setActiveId(null)
+  }
+
+  return { ok: true, value: undefined }
+}

--- a/packages/core/src/application/useCases/setActiveScaffold.ts
+++ b/packages/core/src/application/useCases/setActiveScaffold.ts
@@ -1,0 +1,17 @@
+import type { ScaffoldRepositoryPort } from '../../ports/scaffoldRepository'
+import type { UseCaseResult } from '../result'
+
+export const setActiveScaffold = async (
+  repository: ScaffoldRepositoryPort,
+  id: string,
+): Promise<UseCaseResult<void>> => {
+  const scaffolds = await repository.list()
+  const exists = scaffolds.some((scaffold) => scaffold.id === id)
+
+  if (!exists) {
+    return { ok: false, error: 'scaffold_not_found' }
+  }
+
+  await repository.setActiveId(id)
+  return { ok: true, value: undefined }
+}

--- a/packages/core/src/application/useCases/toggleOverlay.ts
+++ b/packages/core/src/application/useCases/toggleOverlay.ts
@@ -1,0 +1,15 @@
+import type { OverlayPort } from '../../ports/overlayPort'
+import type { UseCaseResult } from '../result'
+
+export const toggleOverlay = async (
+  overlay: OverlayPort,
+  enabled: boolean,
+): Promise<UseCaseResult<void>> => {
+  if (enabled) {
+    await overlay.show()
+  } else {
+    await overlay.hide()
+  }
+
+  return { ok: true, value: undefined }
+}

--- a/packages/core/src/application/useCases/updateOverlayStyle.ts
+++ b/packages/core/src/application/useCases/updateOverlayStyle.ts
@@ -1,0 +1,27 @@
+import {
+  normalizeOverlayStyle,
+  validateOverlayStyle,
+} from '../../domain/overlayStyle'
+import type { OverlayStyle } from '../../domain/overlayStyle'
+import type { OverlayPort } from '../../ports/overlayPort'
+import type { SettingsRepositoryPort } from '../../ports/settingsRepository'
+import type { UseCaseResult } from '../result'
+
+export const updateOverlayStyle = async (
+  settingsRepository: SettingsRepositoryPort,
+  overlay: OverlayPort,
+  patch: Partial<OverlayStyle>,
+): Promise<UseCaseResult<OverlayStyle>> => {
+  const current = await settingsRepository.load()
+  const merged = normalizeOverlayStyle({ ...current.overlayStyle, ...patch })
+  const validation = validateOverlayStyle(merged)
+
+  if (!validation.ok) {
+    return { ok: false, error: 'invalid_overlay_style', issues: validation.issues }
+  }
+
+  await settingsRepository.save({ overlayStyle: validation.value })
+  await overlay.updateStyle(validation.value)
+
+  return { ok: true, value: validation.value }
+}

--- a/packages/core/src/application/useCases/upsertScaffold.ts
+++ b/packages/core/src/application/useCases/upsertScaffold.ts
@@ -1,0 +1,17 @@
+import { validateAnswerScaffold } from '../../domain/answerScaffold'
+import type { AnswerScaffold, AnswerScaffoldInput } from '../../domain/answerScaffold'
+import type { ScaffoldRepositoryPort } from '../../ports/scaffoldRepository'
+import type { UseCaseResult } from '../result'
+
+export const upsertScaffold = async (
+  repository: ScaffoldRepositoryPort,
+  input: AnswerScaffoldInput,
+): Promise<UseCaseResult<AnswerScaffold>> => {
+  const validation = validateAnswerScaffold(input)
+  if (!validation.ok) {
+    return { ok: false, error: 'invalid_scaffold', issues: validation.issues }
+  }
+
+  const saved = await repository.upsert(validation.value)
+  return { ok: true, value: saved }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,7 @@ export type { AnswerScaffold, AnswerScaffoldInput } from './domain/answerScaffol
 export { normalizeAnswerScaffold, validateAnswerScaffold } from './domain/answerScaffold'
 export type { OverlayStyle } from './domain/overlayStyle'
 export { DEFAULT_OVERLAY_STYLE, normalizeOverlayStyle, validateOverlayStyle } from './domain/overlayStyle'
+export type { OverlayPort } from './ports/overlayPort'
+export type { ScaffoldRepositoryPort } from './ports/scaffoldRepository'
+export type { AppSettings, SettingsRepositoryPort } from './ports/settingsRepository'
+export * from './application'

--- a/packages/core/src/ports/overlayPort.ts
+++ b/packages/core/src/ports/overlayPort.ts
@@ -1,0 +1,8 @@
+import type { OverlayStyle } from '../domain/overlayStyle'
+
+export interface OverlayPort {
+  show: () => Promise<void> | void
+  hide: () => Promise<void> | void
+  updateContent: (content: string) => Promise<void> | void
+  updateStyle: (style: Partial<OverlayStyle>) => Promise<void> | void
+}

--- a/packages/core/src/ports/scaffoldRepository.ts
+++ b/packages/core/src/ports/scaffoldRepository.ts
@@ -1,0 +1,9 @@
+import type { AnswerScaffold } from '../domain/answerScaffold'
+
+export interface ScaffoldRepositoryPort {
+  list: () => Promise<AnswerScaffold[]>
+  upsert: (scaffold: AnswerScaffold) => Promise<AnswerScaffold>
+  delete: (id: string) => Promise<void>
+  getActiveId: () => Promise<string | null>
+  setActiveId: (id: string | null) => Promise<void>
+}

--- a/packages/core/src/ports/settingsRepository.ts
+++ b/packages/core/src/ports/settingsRepository.ts
@@ -1,0 +1,10 @@
+import type { OverlayStyle } from '../domain/overlayStyle'
+
+export type AppSettings = {
+  overlayStyle: OverlayStyle
+}
+
+export interface SettingsRepositoryPort {
+  load: () => Promise<AppSettings>
+  save: (settings: AppSettings) => Promise<void>
+}


### PR DESCRIPTION
## Summary
- define core ports for scaffolds, settings, and overlay boundaries
- add V0 use cases (set active, upsert, delete, update overlay, toggle overlay)
- export application layer from core index

## Testing
- not run (core-only)

Closes #7